### PR TITLE
Create the Knowledge Catalog Discovery Agent

### DIFF
--- a/knowledge_catalog_discovery_agent/README.md
+++ b/knowledge_catalog_discovery_agent/README.md
@@ -1,6 +1,6 @@
 # Knowledge Catalog Discovery Agent
 
-## About
+## ℹ️ About
 
 The Knowledge Catalog Discovery Agent is an AI-powered search assistant for discovering data assets in Google Cloud. While standard semantic search only matches semantically similar text, this agent goes further by performing semantic decomposition of complex questions, generating multiple relevant search queries, and reranking the final results to provide a comprehensive answer.
 
@@ -31,8 +31,6 @@ python3 -m venv /tmp/kcsearch
 source /tmp/kcsearch/bin/activate  
 pip3 install -r requirements.txt  
 ```
-
-### Configuration
 
 Set the required environment variables:  
 ```shell
@@ -68,9 +66,8 @@ adk run path/to/agent/parent/folder
 Replace `path/to/agent/parent/folder` with the relative or absolute path to the **parent** directory of the one containing the agent's source code.
 
 
-## References
+## 📚 References
 
 * [Knowledge Catalog Search API](http://docs.cloud.google.com/dataplex/docs/reference/rest/v1/projects.locations/searchEntries)
 * [ADK Documentation](https://adk.dev/get-started/python/#run-your-agent)
 * [Predefined IAM Roles](https://docs.cloud.google.com/iam/docs/roles-permissions)
-

--- a/knowledge_catalog_discovery_agent/README.md
+++ b/knowledge_catalog_discovery_agent/README.md
@@ -1,0 +1,72 @@
+# Knowledge Catalog Discovery Agent
+
+## About
+
+The Knowledge Catalog Discovery Agent is an AI-powered search assistant for discovering data assets in Google Cloud. While standard semantic search only matches semantically similar text, this agent goes further by performing semantic decomposition of complex questions, generating multiple relevant search queries, and reranking the final results to provide a comprehensive answer.
+
+## 🚀 Quick Start
+
+### 1. Prerequisites
+
+You need a Google Cloud project with the following APIs enabled:
+* Knowledge Catalog (`dataplex.googleapis.com`)
+* Vertex AI (`aiplatform.googleapis.com`)
+* Service Usage API (`serviceusage.googleapis.com`)
+
+Ensure you have the following permissions via IAM Roles:
+* `dataplex.projects.search` - can be obtained via roles like `roles/dataplex.viewer`.
+* `aiplatform.endpoints.predict` - can be obtained via roles like `roles/aiplatform.user`.
+* `serviceusage.services.use` - needed to use the current project as the quota project. Can be obtained via roles like `roles/serviceusage.serviceUsageConsumer`.
+
+### 2. Installation
+
+Clone the Github Repository:  
+```shell  
+git clone https://github.com/GoogleCloudPlatform/dataplex-labs.git  
+```
+
+Install the dependencies. It is recommended to create a Python Virtual Environment:  
+```shell  
+python3 -m venv /tmp/kcsearch  
+source /tmp/kcsearch/bin/activate  
+pip3 install -r requirements.txt  
+```
+
+### 3. Configuration
+
+Set the required environment variables:  
+```shell
+
+# Replace <PROJECT_ID> with your consumer project ID.
+export GOOGLE_CLOUD_PROJECT=<PROJECT_ID>
+export GOOGLE_GENAI_USE_VERTEXAI=True
+
+```
+
+### 4. Run the Agent
+
+Run the agent using the ADK CLI:  
+```shell
+adk run path/to/agent/parent/folder
+```
+Replace `path/to/agent/parent/folder` with the relative or absolute path to the **parent** directory of the one containing the agent's source code.
+
+## Suggested Directory Structure
+
+```
+my_custom_agent/
+├── agent.py
+└── knowledge_catalog_discovery_agent/
+    ├── SKILL.md
+    ├── agent.py
+    ├── tools.py
+    └── utils.py
+```
+Replace `my_custom_agent` with the name of the parent agent that is leveraging the Knowledge Catalog Search Agent as a sub-agent.
+
+## References
+
+* [Knowledge Catalog Search API](http://docs.cloud.google.com/dataplex/docs/reference/rest/v1/projects.locations/searchEntries)
+* [ADK Documentation](https://adk.dev/get-started/python/#run-your-agent)
+* [Predefined IAM Roles](https://docs.cloud.google.com/iam/docs/roles-permissions)
+

--- a/knowledge_catalog_discovery_agent/README.md
+++ b/knowledge_catalog_discovery_agent/README.md
@@ -6,7 +6,7 @@ The Knowledge Catalog Discovery Agent is an AI-powered search assistant for disc
 
 ## 🚀 Quick Start
 
-### 1. Prerequisites
+### Prerequisites
 
 You need a Google Cloud project with the following APIs enabled:
 * Knowledge Catalog (`dataplex.googleapis.com`)
@@ -18,7 +18,7 @@ Ensure you have the following permissions via IAM Roles:
 * `aiplatform.endpoints.predict` - can be obtained via roles like `roles/aiplatform.user`.
 * `serviceusage.services.use` - needed to use the current project as the quota project. Can be obtained via roles like `roles/serviceusage.serviceUsageConsumer`.
 
-### 2. Installation
+### Setup
 
 Clone the Github Repository:  
 ```shell  
@@ -32,7 +32,7 @@ source /tmp/kcsearch/bin/activate
 pip3 install -r requirements.txt  
 ```
 
-### 3. Configuration
+### Configuration
 
 Set the required environment variables:  
 ```shell
@@ -43,15 +43,10 @@ export GOOGLE_GENAI_USE_VERTEXAI=True
 
 ```
 
-### 4. Run the Agent
+### Run the Agent
+There are 2 ways to run the Knowledge Catalog Discovery agent:  
 
-Run the agent using the ADK CLI:  
-```shell
-adk run path/to/agent/parent/folder
-```
-Replace `path/to/agent/parent/folder` with the relative or absolute path to the **parent** directory of the one containing the agent's source code.
-
-## Suggested Directory Structure
+1. *As the root agent* - in this case, rename the `discovery_agent` variable in `agent.py` to `root_agent` and run it using ADK CLI (steps below). The recommended parent folder structure in this case is:
 
 ```
 my_custom_agent/
@@ -62,7 +57,16 @@ my_custom_agent/
     ├── tools.py
     └── utils.py
 ```
-Replace `my_custom_agent` with the name of the parent agent that is leveraging the Knowledge Catalog Search Agent as a sub-agent.
+
+2. *As a sub-agent* - in this case, import the Discovery Agent and leverage it as an `AgentTool`. You can find examples of this in the official [ADK docs](https://adk.dev/agents/multi-agents/#c-explicit-invocation-agenttool).
+
+Irrespective of the path you choose, the agent can be run using the ADK CLI commands below:  
+
+```shell
+adk run path/to/agent/parent/folder
+```
+Replace `path/to/agent/parent/folder` with the relative or absolute path to the **parent** directory of the one containing the agent's source code.
+
 
 ## References
 

--- a/knowledge_catalog_discovery_agent/README.md
+++ b/knowledge_catalog_discovery_agent/README.md
@@ -44,7 +44,9 @@ export GOOGLE_GENAI_USE_VERTEXAI=True
 ### Run the Agent
 There are 2 ways to run the Knowledge Catalog Discovery agent:  
 
-1. *As the root agent* - in this case, rename the `discovery_agent` variable in `agent.py` to `root_agent` and run it using ADK CLI (steps below). The recommended parent folder structure in this case is:
+1. *As the root agent* - in this case, rename the `discovery_agent` variable in `agent.py` to `root_agent` and run it using ADK CLI (steps below).
+
+2. *As a sub-agent* - in this case, import the Discovery Agent and leverage it as an `AgentTool`. You can find examples of this in the official [ADK docs](https://adk.dev/agents/multi-agents/#c-explicit-invocation-agenttool). The recommended parent folder structure in this case is:
 
 ```
 my_custom_agent/
@@ -55,8 +57,6 @@ my_custom_agent/
     ├── tools.py
     └── utils.py
 ```
-
-2. *As a sub-agent* - in this case, import the Discovery Agent and leverage it as an `AgentTool`. You can find examples of this in the official [ADK docs](https://adk.dev/agents/multi-agents/#c-explicit-invocation-agenttool).
 
 Irrespective of the path you choose, the agent can be run using the ADK CLI commands below:  
 

--- a/knowledge_catalog_discovery_agent/SKILL.md
+++ b/knowledge_catalog_discovery_agent/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: knowledge_catalog_discovery_agent
+description: >
+  Analyzes user queries, extracts relevant predicates, and utilizes
+  Knowledge Catalog Search to find and rank the most relevant data entries.
+  Engages with the user throughout the process.
+---
+
+You are a proactive and helpful search agent. You take user queries and use Knowledge Catalog Search to find entries that answer the user's questions.
+
+When users ask statistical or analytical questions, you MUST ANSWER THEM BY **finding and returning the results/entries that will allow them to answer their question**. Always assume you can help. Never start by saying "I cannot answer statistical questions" or "I cannot help you with that." Do not ask clarifying questions first; always attempt a search to find entries the user can use.
+
+---
+
+# About Knowledge Catalog Search
+
+Knowledge Catalog Search allows free text search and also allows qualified predicates.
+You can qualify a predicate by prefixing it with a key that restricts the
+matching to a specific piece of metadata:
+
+-   An equal sign (=) restricts the search to an exact match.
+-   A colon (:) after the key matches the predicate to either a substring or a
+    token within the value in the search results. For example:
+-   `name:foo` selects resources with names that contain the foo substring, like
+    foo1 and barfoo.
+
+## How to use Knowledge Catalog Search
+
+*   **Tool Function:** `knowledge_catalog_search(query: str)`
+*   **CRITICAL ARGUMENT RULE:** If the user specifies a project (or
+    if you extract `projectid` predicates), you MUST do the following:
+    1.  **INCLUDE THEM in the `query` string argument.** (e.g., your
+        `query` string must physically contain `projectid=some-project`).
+
+--------------------------------------------------------------------------------
+> [!IMPORTANT] You MUST use these instructions to do search and get the MOST
+> RELEVANT results.
+--------------------------------------------------------------------------------
+
+# Instructions
+
+## Step 1: Understand the query
+
+-   User can provide natural language text (aka free text) as query.
+-   User can also provide predicates, like `type=table`.
+-   Keep the predicates if user has provided it and use it as it is when
+    invoking search
+
+## Step 2: Semantic Decomposition & Generating Variations
+
+-   **Semantic Decomposition:** Read the user request carefully. Break it down into semantic components: identify core entities, required metrics, and critical constraints (types, systems etc.).
+-   **Think Like a Data Engineer:** Users will ask high-level business questions, but you must translate those into how the data is actually stored (e.g., translate "customer acquisition" to "revenue", "billing", "subscriptions", or "accounts").
+-   **Generate Distinct Search Queries:** Based on your decomposition, generate up to 3 DISTINCT search variations to cast a wide net. Scatter and gather is a legitimate strategy, but do NOT duplicate searches or repeat similar semantic queries.
+    *   *Variation 1 (Direct & Synonyms):* Use the user's core terms and apply the "Domain Terminology & Synonyms" list.
+    *   *Variation 2 (Data Source Translation):* Translate the business concept into database terminology based on your decomposition.
+    *   *Variation 3 (Broader System/Category):* Think about the broader business category or related metrics.
+-   **Extract Predicates:** From the user's raw text, extract constraints into valid Knowledge Catalog predicates (e.g., "dataset foo in project your-project-id" becomes `parent=foo projectid=your-project-id`). See the "Predicate Extraction" section. If the user provides `projectid`, you MUST keep them.
+-   **REMINDER** Knowledge Catalog Search DOES NOT UNDERSTAND double quotes in the free text, so avoid introducing any double quotes
+
+## Step 3: Call Knowledge Catalog Search Tools (Batching)
+
+-   Always batch as many search queries as possible in parallel to minimize round trips.
+-   You MUST include the **Baseline Search** alongside your generated variations.
+    -   **Critical Definition - Baseline Search:** A search using the entire user request (word for word) directly.
+-   **REMINDER:** If your predicates include `projectid=X`, those MUST be present inside the `query` string argument.
+-   **REMINDER:** The `name` and `description` predicates MUST ONLY BE USED WHEN THE QUERY EXPLICITLY USES TERMS LIKE "name" or "description".
+
+## Step 3: Call Knowledge Catalog Search
+
+-   Once you have the free text variations and predicates (generated and user
+    provided). Call Knowledge Catalog Search in parallel.
+    -   One search call will be the exact user query
+    -   One search call for each variations along with predicates.
+-   **REMINDER:** If your predicates include `projectid=X`,
+    those MUST be present inside the `query` string argument.
+-  **REMINDER:** The `name` and `description` predicates MUST ONLY BE USED
+    WHEN THE QUERY EXPLICITLY USES TERMS LIKE "name" or "description".
+
+## Step 4: Merge Search Results
+
+-   Deduplicate the results across all the search responses. You can tell two
+    results are same when the entry name is same
+
+## Step 5: Identify the best Results
+
+-   For each result, check the name (display_name) and other details to gauge
+    how close a given results is based on the user query intent.
+-   ONLY RETURN the most relevant results. FILTER OUT irrelevant ones.
+-   MAKE SURE TO SORT THE RESULTS SO THAT MOST RELEVANT results stay at TOP.
+-   RETURN THE FULL **entry name** for each result. NO EXPLANATION required why
+    you selected individual results.
+
+--------------------------------------------------------------------------------
+
+# Predicate Extraction
+
+You MUST follow these four steps for extracting predicates.
+1.  **Analyze Input:** Carefully read the `natural_language_query` provided by
+    the user.
+2.  **Extract Keywords:** Identify distinct words or phrases that carry meaning,
+    such as "BigQuery," "tables," "foo," or "us-central1."
+3.  **Map Keywords to Predicates:** Match the extracted keywords to their
+    corresponding predicate from the **Predicate Reference Table** below. This
+    is the most important step.
+4.  **Construct Query:** Assemble the final search query using the mapped
+    predicates, correct operators, logical `AND` / `OR` connections and correct
+    parentheses placement.
+--------------------------------------------------------------------------------
+### **Rule #1: The Output Format**
+*   Your response MUST be in the following exact format. Do not include any
+    other text, greetings, or explanations.
+*   Do **not** wrap the output in markdown formatting (e.g., \`\`\` or \`).
+*   Do **not** include any newlines after the response.
+set of predicates like: `projectid:your-project-id AND type=table`
+*   If the natural language query is empty, unclear, or does not contain any
+    mappable keywords, the output MUST be an empty set.
+--------------------------------------------------------------------------------
+### **Rule #2: Strict Adherence to Definitions**
+*   **Only Use Official Predicates:** You MUST only use predicates from the
+    **Predicate Reference Table**. If a keyword does not map to a predicate, you
+    MUST ignore it. NEVER invent a new predicate.
+*   **Only Use Allowed Operators:** Each predicate has a specific list of
+    allowed comparison operators. You MUST only use an operator that is valid
+    for that predicate.
+*   **Logical Operators:** The logical operators `AND` and `OR` MUST be in
+    uppercase.
+*   **Negation:** To exclude a term, you MUST prefix the predicate with a hyphen
+    (`-`). For example: `-name:foo`.
+*   **Warning on Logical Expressions:** The placement of parentheses `()` is
+    critical when using logical operators like `AND`, `OR`, and `-`. Ensure that
+    you group conditions correctly to reflect the precise intended logic. For
+    example, `(A AND B) OR C` is not the same as `A AND (B OR C)`. Verify the
+    logical structure of your output to prevent errors.
+*   **Warning on name and description:** The `name` and `description` predicates MUST ONLY BE USED WHEN THE QUERY EXPLICITLY USES TERMS
+     LIKE "name" or "description" to refer to a property of a
+    resource. For example, in "show me all datasets having name xx_yz", `name` is a valid predicate. In contrast, for "give me the names of all systems", the word "names" does not refer to
+    the `name` predicate.
+--------------------------------------------------------------------------------
+### **Predicate Reference Table**
+This is your single source of truth for all predicates.
+| Predicate         | Allowed          | Common Keywords & | Explanation       |
+:                   : Operators        : Triggers          :                   :
+| :---------------- | :--------------- | :---------------- | :---------------- |
+| **`type`**        | `=`              | `table`,          | **(Default        |
+:                   :                  : `tables`,         : Type)** Matches a :
+:                   :                  : `dataset`,        : specific resource :
+:                   :                  : `datasets`        : type.             :
+| **`system`**      | `=`              | `bigquery`,       | Matches the       |
+:                   :                  : `cloud_sql`,      : source system     :
+:                   :                  : `dataplex`        : (e.g., BigQuery). :
+
+| **`description`** | `=`              | `description`     | Matches the text  |
+:                   :                  :                   : in the resource's :
+:                   :                  :                   : description.      :
+| **`name`**        | `:`, `=`, `!=`   | `name`            | Matches the       |
+:                   :                  :                   : resource ID. Use  :
+:                   :                  :                   : `\:` for          :
+:                   :                  :                   : "contains."       :
+| **`displayname`** | `:`, `=`, `!=`   | `display name`    | Matches the       |
+:                   :                  :                   : human-readable    :
+:                   :                  :                   : display name.     :
+| **`projectid`**   | `=`, `:`         | `project`,        | Matches a         |
+:                   :                  : `project id`,     : specific Google   :
+:                   :                  : `projectid`       : Cloud project ID. :
+| **`parent`**      | `=`, `:`         | `parent`          | Matches the       |
+:                   :                  :                   : hierarchical      :
+:                   :                  :                   : parent of a       :
+:                   :                  :                   : resource.         :
+--------------------------------------------------------------------------------
+
+--------------------------------------------------------------------------------
+### **Examples (Study These Carefully)**
+**Example 1: Multiple Predicates** `natural_language_query: Big Query tables
+containing the name foo in project bar` `search_query:
+system=bigquery AND type=table AND name:foo AND projectid=bar`
+**Example 2: Negation** `natural_language_query: Find me all tables not
+containing the name foo` `search_query: type=table AND -name:foo`
+
+**Example 4: Logical OR** `natural_language_query: tables from project foo-1 or
+bar-1.` `search_query: type=table AND (projectid:foo-1 OR projectid:bar-1)`
+**Example 5: Parent Predicate** `natural_language_query: Find all the tables in parent dataset bar.` `search_query: type=table AND parent=bar`
+**Example 6: Ambiguous / Unclear Query** `natural_language_query: foo data`
+`search_query:`
+**Example 7: Very Simple Query** `natural_language_query: Show me all the
+datasets` `search_query: type=dataset`
+**Example 8: Complex Query with tricky parentheses placement**
+`natural_language_query: show me all the table and datasets in project foo or it must be part of bigquery` `search_query: ((type=table OR type=dataset) AND projectid=foo) OR system=bigquery`
+**Example 9: Query having name and description predicate**
+`natural_language_query: show me all the table that contain name sales and
+description pollution` `search_query: type=table AND name:sales AND
+description=pollution`

--- a/knowledge_catalog_discovery_agent/agent.py
+++ b/knowledge_catalog_discovery_agent/agent.py
@@ -1,0 +1,35 @@
+"""Knowledge Catalog Discovery Agent."""
+
+import os
+
+from google.adk.agents import llm_agent
+from google.adk.models import google_llm
+
+from . import tools
+from .utils import get_consumer_project
+
+consumer_project = get_consumer_project()
+GEMINI_MODEL = f"projects/{consumer_project}/locations/global/publishers/google/models/gemini-3-flash-preview"
+
+# Path to the skill file relative to the agent.py location
+SKILL_FILE_PATH = os.path.join(os.path.dirname(__file__), 'SKILL.md')
+
+
+def load_instruction() -> str:
+  """Loads the agent instruction from the SKILL.md file."""
+  with open(SKILL_FILE_PATH, 'r') as f:
+    return f.read()
+
+
+discovery_agent = llm_agent.Agent(
+    model=google_llm.Gemini(model=GEMINI_MODEL),
+    name='knowledge_catalog_discovery_agent',
+    description=(
+        'Searches Knowledge Catalog for data entries based on Natural Language'
+        ' user queries.'
+    ),
+    instruction=load_instruction(),  # Load instruction from file
+    tools=[
+        tools.knowledge_catalog_search,
+    ],
+)

--- a/knowledge_catalog_discovery_agent/requirements.txt
+++ b/knowledge_catalog_discovery_agent/requirements.txt
@@ -1,0 +1,3 @@
+google-adk
+google-cloud-dataplex
+google-api-core

--- a/knowledge_catalog_discovery_agent/tools.py
+++ b/knowledge_catalog_discovery_agent/tools.py
@@ -1,0 +1,71 @@
+"""A collection of tools used by the Knowledge Catalog Search Agent."""
+
+import logging
+import os
+
+from google.api_core.exceptions import PermissionDenied
+from google.cloud import dataplex_v1
+
+from .utils import get_consumer_project
+
+
+def knowledge_catalog_search(
+    query: str,
+) -> dict[str, list[str] | str]:
+  """Searches Knowledge Catalog using Semantic Search capabilities.
+
+  Args:
+      query: The natural language search query.
+
+  Returns:
+      A dictionary containing a list of entries along with their metadata
+      or an error message. For example, {'results': [{'entry_name': 'entry1',
+      'system': 'BIGQUERY', ...}]}.
+  """
+  try:
+    consumer_project_id = get_consumer_project()
+  except ValueError as e:
+    return {"Error obtaining consumer project": str(e)}
+
+  try:
+    endpoint = "dataplex.googleapis.com"
+
+    client = dataplex_v1.CatalogServiceClient(
+        client_options={"api_endpoint": endpoint}
+    )
+
+    parent_name = f"projects/{consumer_project_id}/locations/global"
+    response = client.search_entries(
+        request={
+            "name": parent_name,
+            "query": query,
+            "page_size": 50,
+            "semantic_search": True,
+        }
+    )
+
+    entries = [
+        {
+            "entry_name": result.dataplex_entry.name,
+            "system": result.dataplex_entry.entry_source.system,
+            "resource_id": result.dataplex_entry.entry_source.resource,
+            "display_name": result.dataplex_entry.entry_source.display_name,
+        }
+        for result in response.results
+    ]
+
+    return {"results": entries}
+
+  except PermissionDenied:
+    logging.warning("Knowledge Catalog search failed due to permission error")
+    return {
+        "error": (
+            "Permission denied: The user does not have permission to call"
+            " Knowledge Catalog Search."
+        )
+    }
+  except Exception as e:  # pylint: disable=broad-except
+    logging.exception(
+        "An unexpected error occurred during Knowledge Catalog search"
+    )
+    return {"error": f"An unexpected error occurred: {e}"}

--- a/knowledge_catalog_discovery_agent/utils.py
+++ b/knowledge_catalog_discovery_agent/utils.py
@@ -1,0 +1,20 @@
+"""Utility functions for the Knowledge Catalog Discovery Agent."""
+
+import os
+
+
+def get_consumer_project() -> str:
+  """Extracts the consumer project from the environment variable.
+
+  Returns:
+      The consumer project ID.
+
+  Raises:
+      ValueError: If the GOOGLE_CLOUD_PROJECT environment variable is not set.
+  """
+  consumer_project = os.environ.get("GOOGLE_CLOUD_PROJECT")
+
+  if not consumer_project:
+    raise ValueError("GOOGLE_CLOUD_PROJECT environment variable is required.")
+
+  return consumer_project


### PR DESCRIPTION
## Summary

* Add the Knowledge Catalog Discovery Agent by following the recommended Agent setup practices in the official ADK docs - https://adk.dev/get-started/python/.
* Add a README for users to be able to quickly get started with the Agent.