### PR TITLE
Incorporate Knowledge Catalog LookupContext calls in the Agent Tool & make the search faster

### DIFF
--- a/knowledge_catalog_discovery_agent/SKILL.md
+++ b/knowledge_catalog_discovery_agent/SKILL.md
@@ -26,15 +26,15 @@ matching to a specific piece of metadata:
 
 ## How to use Knowledge Catalog Search
 
-*   **Tool Function:** `knowledge_catalog_search(query: str)`
-*   **CRITICAL ARGUMENT RULE:** If the user specifies a project (or
-    if you extract `projectid` predicates), you MUST do the following:
-    1.  **INCLUDE THEM in the `query` string argument.** (e.g., your
-        `query` string must physically contain `projectid=some-project`).
+*   **Tool Function:** `knowledge_catalog_multi_search(queries: list[str])`
+*   **`queries` Argument:** This is a list of strings, where each string is a search query variation.
+*   **CRITICAL ARGUMENT RULE:** If the user specifies a project (or if you extract `projectid` predicates), you MUST **ALSO INCLUDE THEM in EACH string within the `queries` list.** (e.g., each query string must physically contain `projectid=some-project`).
 
 --------------------------------------------------------------------------------
 > [!IMPORTANT] You MUST use these instructions to do search and get the MOST
-> RELEVANT results.
+> RELEVANT results. You SHOULD NOT CALL multi-search tool again and again. You
+> are ALLOWED to CALL multi-search maximum **3** times. After that just say
+> there are no relevant results.
 --------------------------------------------------------------------------------
 
 # Instructions
@@ -55,40 +55,25 @@ matching to a specific piece of metadata:
     *   *Variation 2 (Data Source Translation):* Translate the business concept into database terminology based on your decomposition.
     *   *Variation 3 (Broader System/Category):* Think about the broader business category or related metrics.
 -   **Extract Predicates:** From the user's raw text, extract constraints into valid Knowledge Catalog predicates (e.g., "dataset foo in project your-project-id" becomes `parent=foo projectid=your-project-id`). See the "Predicate Extraction" section. If the user provides `projectid`, you MUST keep them.
+-   **Include Baseline Search:** Ensure one of the queries in the list is the user's original, word-for-word request.
+-   **Combine Predicates:** Append the extracted predicates (and any user-provided ones) to EACH generated query variation.
 -   **REMINDER** Knowledge Catalog Search DOES NOT UNDERSTAND double quotes in the free text, so avoid introducing any double quotes
 
-## Step 3: Call Knowledge Catalog Search Tools (Batching)
+## Step 3: Call Knowledge Catalog Multi-Search Tool
 
--   Always batch as many search queries as possible in parallel to minimize round trips.
--   You MUST include the **Baseline Search** alongside your generated variations.
+-   Prepare the list of query strings, including the baseline search and all generated variations, each combined with the necessary predicates.
     -   **Critical Definition - Baseline Search:** A search using the entire user request (word for word) directly.
--   **REMINDER:** If your predicates include `projectid=X`, those MUST be present inside the `query` string argument.
+-   Call the `knowledge_catalog_multi_search` tool once with the list of queries.
+-   **REMINDER:** If your predicates include `projectid=X`, those MUST be present inside EACH string in the `queries` list.
 -   **REMINDER:** The `name` and `description` predicates MUST ONLY BE USED WHEN THE QUERY EXPLICITLY USES TERMS LIKE "name" or "description".
 
-## Step 3: Call Knowledge Catalog Search
+## Step 4: Identify the best Results
 
--   Once you have the free text variations and predicates (generated and user
-    provided). Call Knowledge Catalog Search in parallel.
-    -   One search call will be the exact user query
-    -   One search call for each variations along with predicates.
--   **REMINDER:** If your predicates include `projectid=X`,
-    those MUST be present inside the `query` string argument.
--  **REMINDER:** The `name` and `description` predicates MUST ONLY BE USED
-    WHEN THE QUERY EXPLICITLY USES TERMS LIKE "name" or "description".
-
-## Step 4: Merge Search Results
-
--   Deduplicate the results across all the search responses. You can tell two
-    results are same when the entry name is same
-
-## Step 5: Identify the best Results
-
--   For each result, check the name (display_name) and other details to gauge
-    how close a given results is based on the user query intent.
+-   The `knowledge_catalog_multi_search` tool returns a single, deduplicated list of results.
+-   For each result, check the name and description (or other metadata) to gauge how close a given result is based on the user query intent.
 -   ONLY RETURN the most relevant results. FILTER OUT irrelevant ones.
--   MAKE SURE TO SORT THE RESULTS SO THAT MOST RELEVANT results stay at TOP.
--   RETURN THE FULL **entry name** for each result. NO EXPLANATION required why
-    you selected individual results.
+-   **REMINDER:** Do NOT call `knowledge_catalog_multi_search` more than **THRICE** for a single user query. After the third attempt, present the best results found, even if imperfect.
+-   RETURN THE FULL **entry name** for each result. NO EXPLANATION required why you selected individual results.
 
 --------------------------------------------------------------------------------
 

--- a/knowledge_catalog_discovery_agent/agent.py
+++ b/knowledge_catalog_discovery_agent/agent.py
@@ -30,6 +30,6 @@ discovery_agent = llm_agent.Agent(
     ),
     instruction=load_instruction(),  # Load instruction from file
     tools=[
-        tools.knowledge_catalog_search,
+        tools.knowledge_catalog_multi_search,
     ],
 )

--- a/knowledge_catalog_discovery_agent/tools.py
+++ b/knowledge_catalog_discovery_agent/tools.py
@@ -13,7 +13,7 @@ MAX_WORKERS = 5
 
 
 def _lookup_context(region: str, batch_entries: list[str]) -> str:
-  """Calls LookupContext API via the Google Cloud Dataplex Python SDK."""
+  """Calls LookupContext API via the Google Cloud Knowledge Catalog Python SDK."""
   try:
     consumer_project_id = get_consumer_project()
   except ValueError as e:

--- a/knowledge_catalog_discovery_agent/tools.py
+++ b/knowledge_catalog_discovery_agent/tools.py
@@ -141,6 +141,7 @@ def knowledge_catalog_multi_search(
         for q in queries
     ]
 
+    # Retrieve and process search results from each parallel execution, logging any issues
     for i, future in enumerate(future_to_query):
       query = queries[i]
       try:
@@ -177,6 +178,7 @@ def _deduplicate_and_fetch_context(
 
   max_depth = max((len(res) for res in query_results_list), default=0)
 
+  # Interleave and deduplicate results from different queries round-robin style to preserve relevance order
   for depth in range(max_depth):
     for result_set in query_results_list:
       if depth < len(result_set):

--- a/knowledge_catalog_discovery_agent/tools.py
+++ b/knowledge_catalog_discovery_agent/tools.py
@@ -1,5 +1,6 @@
 """A collection of tools used by the Knowledge Catalog Search Agent."""
 
+import concurrent.futures
 import logging
 import os
 
@@ -8,8 +9,44 @@ from google.cloud import dataplex_v1
 
 from .utils import get_consumer_project
 
+MAX_WORKERS = 5
 
-def knowledge_catalog_search(
+
+def _lookup_context(region: str, batch_entries: list[str]) -> str:
+  """Calls LookupContext API via the Google Cloud Dataplex Python SDK."""
+  try:
+    consumer_project_id = get_consumer_project()
+  except ValueError as e:
+    return f"Error obtaining consumer project: {e}"
+
+  try:
+    client = dataplex_v1.CatalogServiceClient(
+        client_options={"api_endpoint": "dataplex.googleapis.com"}
+    )
+    parent_name = f"projects/{consumer_project_id}/locations/{region}"
+    request = dataplex_v1.LookupContextRequest(
+        name=parent_name,
+        resources=batch_entries,
+    )
+    logging.info(
+        "Sending LookupContext request for parent %s with resources %s",
+        parent_name,
+        batch_entries,
+    )
+    response = client.lookup_context(request=request)
+    return response.context
+  except Exception as e:  # pylint: disable=broad-except
+    logging.warning(
+        "LookupContext failed for batch %s in %s: %s",
+        batch_entries,
+        region,
+        e,
+    )
+    return f"Error retrieving context for {batch_entries}: {e}"
+
+
+
+def _knowledge_catalog_search(
     query: str,
 ) -> dict[str, list[str] | str]:
   """Searches Knowledge Catalog using Semantic Search capabilities.
@@ -69,3 +106,126 @@ def knowledge_catalog_search(
         "An unexpected error occurred during Knowledge Catalog search"
     )
     return {"error": f"An unexpected error occurred: {e}"}
+
+
+def knowledge_catalog_multi_search(
+    queries: list[str],
+) -> dict[str, list[dict[str, str]] | str]:
+  """Performs multiple Knowledge Catalog searches in parallel and merges results.
+
+  Uses a Round-Robin interleaving strategy to maintain original relevance
+  rankings as much as possible while deduplicating results.
+  Also fetches rich context using LookupContext API for the merged results.
+
+  Args:
+      queries: A list of natural language search queries. The order of queries
+        influences the final result order.
+
+  Returns:
+      A dictionary containing a list of search results under the 'results' key,
+      combined context under 'combined_context' key, or error messages.
+  """
+  if not queries:
+    return {"results": []}
+
+  page_size = 100
+  query_results_list: list[list[dict[str, str]]] = []
+  errors: list[str] = []
+
+
+  with concurrent.futures.ThreadPoolExecutor(
+      max_workers=MAX_WORKERS
+  ) as executor:
+    future_to_query = [
+        executor.submit(_knowledge_catalog_search, q)
+        for q in queries
+    ]
+
+    for i, future in enumerate(future_to_query):
+      query = queries[i]
+      try:
+        result = future.result()
+        if "results" in result and isinstance(result["results"], list):
+          query_results_list.append(result["results"])
+        elif "error" in result:
+          logging.warning("Error for query '%s': %s", query, result["error"])
+          errors.append(str(result["error"]))
+          query_results_list.append([])
+        else:
+          error_msg = next(iter(result.values())) if result else "Unknown error"
+          logging.warning("Error for query '%s': %s", query, error_msg)
+          errors.append(str(error_msg))
+          query_results_list.append([])
+      except Exception as exc:  # pylint: disable=broad-except
+        logging.exception("Exception for query '%s': %s", query, exc)
+        errors.append(f"Exception: {exc}")
+        query_results_list.append([])
+
+  if errors and len(errors) == len(queries):
+    return {"error": "All search queries failed.", "details": errors}
+
+  return _deduplicate_and_fetch_context(query_results_list, page_size)
+
+
+def _deduplicate_and_fetch_context(
+    query_results_list: list[list[dict[str, str]]],
+    page_size: int = 100,
+) -> dict[str, list[dict[str, str]] | str]:
+  """Deduplicates query results using round-robin and retrieves context."""
+  final_results = []
+  seen_names = set()
+
+  max_depth = max((len(res) for res in query_results_list), default=0)
+
+  for depth in range(max_depth):
+    for result_set in query_results_list:
+      if depth < len(result_set):
+        item = result_set[depth]
+        entry_name = item.get("entry_name")
+        if entry_name and entry_name not in seen_names:
+          final_results.append(item)
+          seen_names.add(entry_name)
+          if len(final_results) == page_size:
+            break
+    if len(final_results) == page_size:
+      break
+
+  # Group entries by GCP region
+  entries_by_region = {}
+  for item in final_results:
+    entry_name = item["entry_name"]
+    parts = entry_name.split("/")
+    current_location = "global"
+    if len(parts) >= 4 and parts[0] == "projects" and parts[2] == "locations":
+      current_location = parts[3]
+
+    if current_location not in entries_by_region:
+      entries_by_region[current_location] = []
+    entries_by_region[current_location].append(entry_name)
+
+  # Partition entries into regional batches of maximum size 10
+  batches = []
+  for region, items in entries_by_region.items():
+    for i in range(0, len(items), 10):
+      batches.append((region, items[i : i + 10]))
+
+  lookup_context_max_workers = 2
+  # Fetch context concurrently for each regional batch using ThreadPoolExecutor
+  with concurrent.futures.ThreadPoolExecutor(
+      max_workers=lookup_context_max_workers
+  ) as executor:
+    futures = [
+        executor.submit(_lookup_context, region, batch)
+        for region, batch in batches
+    ]
+    concurrent.futures.wait(futures)
+    regional_contexts = [f.result() for f in futures]
+
+  # Combine and return regional contexts along with the final deduplicated results
+  combined_context = "\n\n".join(filter(None, regional_contexts))
+
+  return {
+      "results": final_results,
+      "combined_context": combined_context,
+  }
+

--- a/knowledge_catalog_discovery_agent/tools.py
+++ b/knowledge_catalog_discovery_agent/tools.py
@@ -4,12 +4,21 @@ import concurrent.futures
 import logging
 import os
 
+from google.api_core import retry
 from google.api_core.exceptions import PermissionDenied
 from google.cloud import dataplex_v1
 
 from .utils import get_consumer_project
 
 MAX_WORKERS = 5
+
+TRANSIENT_RETRY = retry.Retry(
+    predicate=retry.if_transient_error,
+    initial=2.0,
+    maximum=2.0,
+    multiplier=1.0,
+    timeout=9.0,
+)
 
 
 def _lookup_context(region: str, batch_entries: list[str]) -> str:
@@ -33,7 +42,7 @@ def _lookup_context(region: str, batch_entries: list[str]) -> str:
         parent_name,
         batch_entries,
     )
-    response = client.lookup_context(request=request)
+    response = client.lookup_context(request=request, retry=TRANSIENT_RETRY)
     return response.context
   except Exception as e:  # pylint: disable=broad-except
     logging.warning(
@@ -78,7 +87,8 @@ def _knowledge_catalog_search(
             "query": query,
             "page_size": 50,
             "semantic_search": True,
-        }
+        },
+        retry=TRANSIENT_RETRY,
     )
 
     entries = [


### PR DESCRIPTION
Here, we're making the following modifications:

- Offload the parallel Search calls to the tool rather than the Agent. This makes the calls more predictable and hence faster.
- Incorporate LookupContext calls in the Tool. This helps the Agent get context about the returned resources and rank the resources better. This is improving the precision by ~8% when tested on the [Bird-SQL Dataset](https://bird-bench.github.io/).